### PR TITLE
General improvements...

### DIFF
--- a/src/Bridge/AbstractUploadableBridge.php
+++ b/src/Bridge/AbstractUploadableBridge.php
@@ -3,6 +3,7 @@
 namespace Santeacademie\SuperUploaderBundle\Bridge;
 
 use Santeacademie\SuperUploaderBundle\Asset\Variant\AbstractVariant;
+use Santeacademie\SuperUploaderBundle\Interface\UploadableInterface;
 
 abstract class AbstractUploadableBridge
 {
@@ -32,14 +33,14 @@ abstract class AbstractUploadableBridge
         return $this->isAbsolutePublicDirEnabled() ? $this->appPublicDir.'/' : '';
     }
 
-    public function getVariantFileName(AbstractVariant $variant, string $extension = '', string $suffix = '')
+    public function getVariantFileName(AbstractVariant $variant, UploadableInterface $uploadableEntity = null, string $extension = ''): string
     {
-        // trainer_profile-rectangle[suffix][.extension]
+        // trainer_profile-rectangle[-hash][.extension]
         return sprintf('%s-%s%s%s',
             $variant->getAsset()->getName(),
             $variant->getName(),
-            empty($suffix)      ? '' : '-'.$suffix,
-            empty($extension)   ? '' : '.'.$extension
+            empty($uploadableEntity) ? '' : '-' . md5(sprintf('%s-%s-%s', $variant->getAsset()->getName(), $variant->getName(), $uploadableEntity->getUploadableKeyValue())),
+            empty($extension)        ? '' : '.' . $extension,
         );
     }
 

--- a/src/Bridge/UploadableEntityBridge.php
+++ b/src/Bridge/UploadableEntityBridge.php
@@ -56,35 +56,6 @@ class UploadableEntityBridge extends AbstractUploadableBridge
         }
     }
 
-
-    /**
-     * @throws PlaceholderNotFound
-     * @throws FilesystemException
-     * @throws FileNotFoundException
-     */
-    public function getPublicUrl(
-        UploadableInterface $entity,
-        string $assetName,
-        string $variantName,
-        bool $fallbackResource = AbstractVariant::DEFAULT_FALLBACK_RESOURCE
-    ): string
-    {
-        try {
-
-
-            $file = $this->getNamedEntityAssetVariantFile($entity, $assetName, $variantName, $fallbackResource);
-
-            if (!$file) {
-                throw new FileNotFoundException();
-            }
-
-            return $this->uploadsFilesystem->publicUrl($file->getPathname());
-
-        } catch (FileNotFoundException|PlaceholderNotFound $exception) {
-            return '';
-        }
-    }
-
     public function getNamedEntityAssetVariantFile(
         UploadableInterface $entity,
         string $assetName,

--- a/src/Bridge/UploadablePersistentBridge.php
+++ b/src/Bridge/UploadablePersistentBridge.php
@@ -45,7 +45,7 @@ class UploadablePersistentBridge extends AbstractUploadableBridge
     {
         $asset = $variant->getAsset();
         $entityAssetPath = $this->getUploadEntityAssetPath($uploadableEntity, $asset, true);
-        $variantFileNamePrefix = $this->getVariantFileName($variant);
+        $variantFileNamePrefix = $this->getVariantFileName($variant, uploadableEntity: $uploadableEntity);
 
         //variantFileName = $this->getVariantFileName($variant, $variant->getTemporaryFile()->guessExtension(), StringUtil::generateRandomPassword());
         // Reuse old temporary name (important)

--- a/src/Bridge/UploadablePersistentBridge.php
+++ b/src/Bridge/UploadablePersistentBridge.php
@@ -114,8 +114,8 @@ class UploadablePersistentBridge extends AbstractUploadableBridge
             ->setAssetClass(get_class($asset))
             ->setVariantClass(get_class($variant))
             ->setVariantTypeClass($variant->getVariantTypeClass())
-            ->setFileExtension($this->filesystem->mimeType($variantFile))
-            ->setFileSize((float) $this->filesystem->fileSize($variantFile))
+            ->setFileExtension($variantFile->guessExtension())
+            ->setFileSize((float) $variantFile->getSize())
         ;
 
         if (property_exists($variant, 'width')) {

--- a/src/Bridge/UploadableTemporaryBridge.php
+++ b/src/Bridge/UploadableTemporaryBridge.php
@@ -61,7 +61,7 @@ class UploadableTemporaryBridge extends AbstractUploadableBridge
 
         $temporaryFullName = sprintf('%s/%s',
             $this->getTemporaryPath(true, $variant->getAsset()->getMediaType()),
-            $this->getVariantFileName($variant, $variant->getExtension(), StringUtil::generateRandomPassword())
+            $this->getVariantFileName($variant, $uploadableEntity, $variant->getExtension())
         );
 
         $temporaryVariantFile = new TemporaryFile($temporaryFullName, false, $this->filesystem);

--- a/src/Generator/FallbackResourcesGenerator.php
+++ b/src/Generator/FallbackResourcesGenerator.php
@@ -34,7 +34,7 @@ class FallbackResourcesGenerator
     private function generatePictureVariantResource(UploadableInterface $entity, PictureVariant $variant): File
     {
         $assetPath = $this->getFallbackRessourceAssetPath($entity, $variant->getAsset(), true);
-        $variantResourceFileName = $this->uploadableEntityBridge->getVariantFileName($variant, 'png');
+        $variantResourceFileName = $this->uploadableEntityBridge->getVariantFileName($variant, extension: 'png');
         $resourceFile = new SuperFile(sprintf('%s/%s', $assetPath, $variantResourceFileName), false, $this->filesystem);
 
         $fontSize = $variant->getWidth() / 12;
@@ -90,7 +90,7 @@ class FallbackResourcesGenerator
                 $assetPath = $this->getFallbackRessourceAssetPath($object, $asset, true);
 
                 if ($reset) {
-                    $this->filesystem->delete($assetPath);
+                    $this->filesystem->deleteDirectory($assetPath);
                 }
 
                 $files[$name][$asset->getName()] = [];
@@ -108,13 +108,7 @@ class FallbackResourcesGenerator
 
     private function getFallbackRessourceAssetPath(UploadableInterface $entity, AbstractAsset $asset, bool $create = false): string
     {
-        $dir = $this->uploadableEntityBridge->getFallbackRessourceAssetPath($entity, $asset, false);
-
-        if (!$this->filesystem->directoryExists($dir) && $create) {
-            $this->filesystem->createDirectory($dir);
-        }
-
-        return $dir;
+        return $this->uploadableEntityBridge->getFallbackRessourceAssetPath($entity, $asset);
     }
 
     private function getFontPath(): string

--- a/src/Twig/UploaderTwigExtension.php
+++ b/src/Twig/UploaderTwigExtension.php
@@ -4,8 +4,6 @@ namespace Santeacademie\SuperUploaderBundle\Twig;
 
 use Santeacademie\SuperUploaderBundle\Asset\Variant\AbstractVariant;
 use Santeacademie\SuperUploaderBundle\Bridge\UploadableEntityBridge;
-use Santeacademie\SuperUploaderBundle\Exception\FileNotFoundException;
-use Santeacademie\SuperUploaderBundle\Exception\PlaceholderNotFound;
 use Santeacademie\SuperUploaderBundle\Interface\UploadableInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -28,11 +26,7 @@ class UploaderTwigExtension extends AbstractExtension
 
     public function getUploadable(UploadableInterface $entity, string $assetName, string $variantName, bool $fallbackResource = AbstractVariant::DEFAULT_FALLBACK_RESOURCE): string
     {
-
-        try {
-            return $this->uploadableEntityBridge->getPublicUrl($entity, $assetName, $variantName, $fallbackResource);
-        } catch (FileNotFoundException|PlaceholderNotFound $exception) {
-            return '';
-        }
+        $file = $this->uploadableEntityBridge->getNamedEntityAssetVariantFile($entity, $assetName, $variantName, $fallbackResource);
+        return $file ?? '';
     }
 }

--- a/src/Wrapper/SuperFile.php
+++ b/src/Wrapper/SuperFile.php
@@ -35,6 +35,13 @@ class SuperFile extends File
         return $this->filesystemOperator->mimeType($this->getPathname());
     }
 
+    public function guessExtension(): ?string
+    {
+        $mimeTypes = new MimeTypes();
+        $exts = $mimeTypes->getExtensions($this->filesystemOperator->mimeType($this->getPathname()));
+        return $exts[0];
+    }
+
     public function __toString(): string
     {
         return $this->publicUrl();

--- a/src/Wrapper/SuperFile.php
+++ b/src/Wrapper/SuperFile.php
@@ -42,6 +42,11 @@ class SuperFile extends File
         return $exts[0];
     }
 
+    public function getSize(): ?string
+    {
+        return $this->filesystemOperator->fileSize($this->getPathname());
+    }
+
     public function __toString(): string
     {
         return $this->publicUrl();

--- a/src/Wrapper/SuperFile.php
+++ b/src/Wrapper/SuperFile.php
@@ -24,4 +24,19 @@ class SuperFile extends File
     {
         return $this->filesystemOperator->read($this->getPathname());
     }
+
+    public function publicUrl(): string
+    {
+        return $this->filesystemOperator->publicUrl($this->getPathname());
+    }
+
+    public function getMimeType(): ?string
+    {
+        return $this->filesystemOperator->mimeType($this->getPathname());
+    }
+
+    public function __toString(): string
+    {
+        return $this->publicUrl();
+    }
 }


### PR DESCRIPTION
Content of this pull request:
- Replaced a randomly generated string in the `getVariantFileName` method with a hash made from the entity ID, the asset name, and the variant name.
- Deleted the `getPublicUrl` method, which is no longer needed in the current context.
- Removed unnecessary `$filesystem->createDirectory()` calls, as Flysystem automatically creates directories when needed.
- `SuperFile`'s object now return their `publicUrl` instead of the path when casting to string to add the Flysystem prefix