### PR TITLE
Ne pas modifier le pathname d'un fichier si celui-ci est le même

### DIFF
--- a/src/Bridge/UploadableTemporaryBridge.php
+++ b/src/Bridge/UploadableTemporaryBridge.php
@@ -61,7 +61,7 @@ class UploadableTemporaryBridge extends AbstractUploadableBridge
 
         $temporaryFullName = sprintf('%s/%s',
             $this->getTemporaryPath(true, $variant->getAsset()->getMediaType()),
-            $this->getVariantFileName($variant, $variant->getExtension(), StringUtil::generateRandomPassword())
+            $this->getVariantFileName($variant, $variant->getExtension(), md5($genuineFile->getContent()))
         );
 
         $temporaryVariantFile = new TemporaryFile($temporaryFullName, false, $this->filesystem);

--- a/src/Repository/VariantEntityMapRepository.php
+++ b/src/Repository/VariantEntityMapRepository.php
@@ -38,8 +38,8 @@ final class VariantEntityMapRepository implements VariantEntityMapRepositoryInte
 
         // Construct the SQL query
         $sql = sprintf(
-            "INSERT INTO %s.%s (%s) VALUES (%s)",
-            $metadata->getSchemaName(),
+            "INSERT INTO %s%s (%s) VALUES (%s)",
+            $metadata->getSchemaName() ? sprint('%s.', $metadata->getSchemaName()) : '',
             $metadata->getTableName(),
             implode(',', $columns),
             implode(',', $placeholders)


### PR DESCRIPTION

Le choix a été fait de ne plus avoir un suffix généré aléatoirement mais à la place que ce soit le md5 du contenu du fichier
